### PR TITLE
[Section 13] Spring Framework Testing Context

### DIFF
--- a/src/main/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreter.java
+++ b/src/main/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreter.java
@@ -1,0 +1,20 @@
+package com.udemy.junit_lecture_1.contextPractice;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class HearingInterpreter {
+
+    private final WordProducer wordProducer;
+
+    public String whatIHeard() {
+        String word = wordProducer.getWord();
+
+        System.out.println(word);
+
+        return word;
+    }
+}

--- a/src/main/java/com/udemy/junit_lecture_1/contextPractice/LaurelWordProducer.java
+++ b/src/main/java/com/udemy/junit_lecture_1/contextPractice/LaurelWordProducer.java
@@ -1,0 +1,13 @@
+package com.udemy.junit_lecture_1.contextPractice;
+
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+@Component
+@Primary
+public class LaurelWordProducer implements WordProducer {
+    @Override
+    public String getWord() {
+        return "Laurel";
+    }
+}

--- a/src/main/java/com/udemy/junit_lecture_1/contextPractice/LaurelWordProducer.java
+++ b/src/main/java/com/udemy/junit_lecture_1/contextPractice/LaurelWordProducer.java
@@ -1,10 +1,8 @@
 package com.udemy.junit_lecture_1.contextPractice;
 
-import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 @Component
-@Primary
 public class LaurelWordProducer implements WordProducer {
     @Override
     public String getWord() {

--- a/src/main/java/com/udemy/junit_lecture_1/contextPractice/PropertiesWordProducer.java
+++ b/src/main/java/com/udemy/junit_lecture_1/contextPractice/PropertiesWordProducer.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("externalized")
+@Profile({"externalized", "laurel-properties"})
 @Primary
 public class PropertiesWordProducer implements WordProducer {
     private String word;

--- a/src/main/java/com/udemy/junit_lecture_1/contextPractice/PropertiesWordProducer.java
+++ b/src/main/java/com/udemy/junit_lecture_1/contextPractice/PropertiesWordProducer.java
@@ -1,0 +1,25 @@
+package com.udemy.junit_lecture_1.contextPractice;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("externalized")
+@Primary
+public class PropertiesWordProducer implements WordProducer {
+    private String word;
+
+    @Value("${say.word}")
+    public void setWord(String word) {
+        this.word = word;
+    }
+
+    @Override
+    public String getWord() {
+        return word;
+    }
+}
+
+

--- a/src/main/java/com/udemy/junit_lecture_1/contextPractice/WordProducer.java
+++ b/src/main/java/com/udemy/junit_lecture_1/contextPractice/WordProducer.java
@@ -1,0 +1,5 @@
+package com.udemy.junit_lecture_1.contextPractice;
+
+public interface WordProducer {
+    String getWord();
+}

--- a/src/main/java/com/udemy/junit_lecture_1/contextPractice/YannyWordProducer.java
+++ b/src/main/java/com/udemy/junit_lecture_1/contextPractice/YannyWordProducer.java
@@ -1,8 +1,12 @@
 package com.udemy.junit_lecture_1.contextPractice;
 
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
+@Profile("yanny")
+@Primary
 public class YannyWordProducer implements WordProducer {
     @Override
     public String getWord() {

--- a/src/main/java/com/udemy/junit_lecture_1/contextPractice/YannyWordProducer.java
+++ b/src/main/java/com/udemy/junit_lecture_1/contextPractice/YannyWordProducer.java
@@ -1,0 +1,11 @@
+package com.udemy.junit_lecture_1.contextPractice;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class YannyWordProducer implements WordProducer {
+    @Override
+    public String getWord() {
+        return "Yanny";
+    }
+}

--- a/src/main/resources/laurel.properties
+++ b/src/main/resources/laurel.properties
@@ -1,0 +1,1 @@
+say.word=LAUrEl

--- a/src/main/resources/yanny.properties
+++ b/src/main/resources/yanny.properties
@@ -1,0 +1,1 @@
+say.word=YaNNy

--- a/src/test/java/com/udemy/junit_lecture_1/contextPractice/BaseConfig.java
+++ b/src/test/java/com/udemy/junit_lecture_1/contextPractice/BaseConfig.java
@@ -1,0 +1,12 @@
+package com.udemy.junit_lecture_1.contextPractice;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class BaseConfig {
+    @Bean
+    HearingInterpreter hearingInterpreter(WordProducer wordProducer) {
+        return new HearingInterpreter(wordProducer);
+    }
+}

--- a/src/test/java/com/udemy/junit_lecture_1/contextPractice/BaseConfig.java
+++ b/src/test/java/com/udemy/junit_lecture_1/contextPractice/BaseConfig.java
@@ -2,7 +2,9 @@ package com.udemy.junit_lecture_1.contextPractice;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
+@Profile("base-test")
 @Configuration
 public class BaseConfig {
     @Bean

--- a/src/test/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreterActiveProfileTest.java
+++ b/src/test/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreterActiveProfileTest.java
@@ -6,15 +6,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-@ActiveProfiles("component-scan")
-@SpringJUnitConfig(classes = HearingInterpreterComponentScanTest.TestConfig.class)
-class HearingInterpreterComponentScanTest {
+@ActiveProfiles("yanny")
+@SpringJUnitConfig(classes = HearingInterpreterActiveProfileTest.TestConfig.class)
+class HearingInterpreterActiveProfileTest {
+
     @Configuration
-    @Profile("component-scan")
     @ComponentScan("com.udemy.junit_lecture_1.contextPractice")
     static class TestConfig {
     }
@@ -26,6 +25,6 @@ class HearingInterpreterComponentScanTest {
     void whatIHeard() {
         String word = hearingInterpreter.whatIHeard();
 
-        assertEquals("Laurel", word);
+        assertEquals("Yanny", word);
     }
 }

--- a/src/test/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreterComponentScanTest.java
+++ b/src/test/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreterComponentScanTest.java
@@ -1,0 +1,27 @@
+package com.udemy.junit_lecture_1.contextPractice;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig(classes = HearingInterpreterComponentScanTest.TestConfig.class)
+class HearingInterpreterComponentScanTest {
+    @Configuration
+    @ComponentScan("com.udemy.junit_lecture_1.contextPractice")
+    static class TestConfig {
+    }
+
+    @Autowired
+    HearingInterpreter hearingInterpreter;
+
+    @Test
+    void whatIHeard() {
+        String word = hearingInterpreter.whatIHeard();
+
+        assertEquals("Laurel", word);
+    }
+}

--- a/src/test/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreterInnerClassTest.java
+++ b/src/test/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreterInnerClassTest.java
@@ -6,12 +6,16 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
+@ActiveProfiles("inner-class")
 @SpringJUnitConfig(classes = HearingInterpreterInnerClassTest.TestConfig.class)
 class HearingInterpreterInnerClassTest {
 
     @Configuration
+    @Profile("inner-class")
     static class TestConfig {
         @Bean
         HearingInterpreter hearingInterpreter() {

--- a/src/test/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreterInnerClassTest.java
+++ b/src/test/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreterInnerClassTest.java
@@ -1,0 +1,31 @@
+package com.udemy.junit_lecture_1.contextPractice;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig(classes = HearingInterpreterInnerClassTest.TestConfig.class)
+class HearingInterpreterInnerClassTest {
+
+    @Configuration
+    static class TestConfig {
+        @Bean
+        HearingInterpreter hearingInterpreter() {
+            return new HearingInterpreter(new LaurelWordProducer());
+        }
+    }
+
+    @Autowired
+    HearingInterpreter hearingInterpreter;
+
+    @Test
+    void whatIHeard() {
+        String word = hearingInterpreter.whatIHeard();
+
+        assertEquals("Laurel", word);
+    }
+}

--- a/src/test/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreterLaurelTest.java
+++ b/src/test/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreterLaurelTest.java
@@ -4,8 +4,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
+@ActiveProfiles("base-test")
 @SpringJUnitConfig(classes = {BaseConfig.class, LaurelConfig.class})
 class HearingInterpreterLaurelTest {
 

--- a/src/test/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreterLaurelTest.java
+++ b/src/test/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreterLaurelTest.java
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = {BaseConfig.class, LaurelConfig.class})
-class HearingInterpreterTest {
+class HearingInterpreterLaurelTest {
 
     @Autowired
     HearingInterpreter hearingInterpreter;

--- a/src/test/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreterTest.java
+++ b/src/test/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreterTest.java
@@ -1,0 +1,21 @@
+package com.udemy.junit_lecture_1.contextPractice;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig(classes = {BaseConfig.class, LaurelConfig.class})
+class HearingInterpreterTest {
+
+    @Autowired
+    HearingInterpreter hearingInterpreter;
+
+    @Test
+    void whatIHeard() {
+        String word = hearingInterpreter.whatIHeard();
+
+        assertEquals("Laurel", word);
+    }
+}

--- a/src/test/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreterYannyTest.java
+++ b/src/test/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreterYannyTest.java
@@ -4,9 +4,11 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 // JUnit 4와 JUnit 5에서 context를 관리하는 어노테이션 사용법이 조금 다르다.
+@ActiveProfiles("base-test")
 @SpringJUnitConfig(classes = {BaseConfig.class, YannyConfig.class})
 class HearingInterpreterYannyTest {
 

--- a/src/test/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreterYannyTest.java
+++ b/src/test/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreterYannyTest.java
@@ -1,0 +1,21 @@
+package com.udemy.junit_lecture_1.contextPractice;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig(classes = {BaseConfig.class, YannyConfig.class})
+class HearingInterpreterYannyTest {
+
+    @Autowired
+    HearingInterpreter hearingInterpreter;
+
+    @Test
+    void whatIHeard() {
+        String word = hearingInterpreter.whatIHeard();
+
+        assertEquals("Yanny", word);
+    }
+}

--- a/src/test/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreterYannyTest.java
+++ b/src/test/java/com/udemy/junit_lecture_1/contextPractice/HearingInterpreterYannyTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
+// JUnit 4와 JUnit 5에서 context를 관리하는 어노테이션 사용법이 조금 다르다.
 @SpringJUnitConfig(classes = {BaseConfig.class, YannyConfig.class})
 class HearingInterpreterYannyTest {
 

--- a/src/test/java/com/udemy/junit_lecture_1/contextPractice/LaurelConfig.java
+++ b/src/test/java/com/udemy/junit_lecture_1/contextPractice/LaurelConfig.java
@@ -1,0 +1,12 @@
+package com.udemy.junit_lecture_1.contextPractice;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LaurelConfig {
+    @Bean
+    LaurelWordProducer laurelWordProducer() {
+        return new LaurelWordProducer();
+    }
+}

--- a/src/test/java/com/udemy/junit_lecture_1/contextPractice/LaurelConfig.java
+++ b/src/test/java/com/udemy/junit_lecture_1/contextPractice/LaurelConfig.java
@@ -2,8 +2,10 @@ package com.udemy.junit_lecture_1.contextPractice;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
+@Profile("base-test")
 public class LaurelConfig {
     @Bean
     LaurelWordProducer laurelWordProducer() {

--- a/src/test/java/com/udemy/junit_lecture_1/contextPractice/PropertiesLaurelTest.java
+++ b/src/test/java/com/udemy/junit_lecture_1/contextPractice/PropertiesLaurelTest.java
@@ -1,0 +1,31 @@
+package com.udemy.junit_lecture_1.contextPractice;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@TestPropertySource("classpath:laurel.properties")
+@ActiveProfiles("laurel-properties")
+@SpringJUnitConfig(classes = PropertiesLaurelTest.TestConfig.class)
+public class PropertiesLaurelTest {
+    @Configuration
+    @ComponentScan("com.udemy.junit_lecture_1.contextPractice")
+    static class TestConfig {
+    }
+
+    @Autowired
+    HearingInterpreter hearingInterpreter;
+
+    @Test
+    void whatIHeard() {
+        String word = hearingInterpreter.whatIHeard();
+
+        assertEquals("LAUrEl", word);
+    }
+}

--- a/src/test/java/com/udemy/junit_lecture_1/contextPractice/PropertiesTest.java
+++ b/src/test/java/com/udemy/junit_lecture_1/contextPractice/PropertiesTest.java
@@ -1,0 +1,31 @@
+package com.udemy.junit_lecture_1.contextPractice;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@TestPropertySource("classpath:yanny.properties")
+@ActiveProfiles("externalized")
+@SpringJUnitConfig(classes = PropertiesTest.TestConfig.class)
+public class PropertiesTest {
+    @Configuration
+    @ComponentScan("com.udemy.junit_lecture_1.contextPractice")
+    static class TestConfig {
+    }
+
+    @Autowired
+    HearingInterpreter hearingInterpreter;
+
+    @Test
+    void whatIHeard() {
+        String word = hearingInterpreter.whatIHeard();
+
+        assertEquals("YaNNy", word);
+    }
+}

--- a/src/test/java/com/udemy/junit_lecture_1/contextPractice/YannyConfig.java
+++ b/src/test/java/com/udemy/junit_lecture_1/contextPractice/YannyConfig.java
@@ -1,0 +1,12 @@
+package com.udemy.junit_lecture_1.contextPractice;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class YannyConfig {
+    @Bean
+    YannyWordProducer yannyWordProducer() {
+        return new YannyWordProducer();
+    }
+}

--- a/src/test/java/com/udemy/junit_lecture_1/contextPractice/YannyConfig.java
+++ b/src/test/java/com/udemy/junit_lecture_1/contextPractice/YannyConfig.java
@@ -2,8 +2,10 @@ package com.udemy.junit_lecture_1.contextPractice;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
+@Profile("base-test")
 public class YannyConfig {
     @Bean
     YannyWordProducer yannyWordProducer() {


### PR DESCRIPTION
<!-- PR 제목 형식 -->
<!-- [Section 3] Section title -->

## What has changed?

<!-- 강의 내용이나 코드의 내용에 대해 간단히 정리합니다 -->

* `JUnit 5` 테스트 할 때 `Spring Context`를 관리하는 방법 - `@SpringJUnitConfig` 이용
  * 외부에서 `@Configuration`, `@Bean`을 이용하여 Bean 등록
  * 내부에서 클래스를 구현, `@Configuration`, `@Bean` 이용하여 Bean 등록
  * 내부에서 클래스를 구현, `@ComponentScan`을 이용하여 원래 Component가 있던 패키지 경로를 입력하여 Bean 등록
* 같은 interface를 구현한 `Component`가 여러 개 일 때 `@Profile`로 관리하는 방법
  * Test에서는 `@ActiveProfiles`을 이용하여 Bean 등록
  * 한 `Component`에 `Profile` 여러 개 등록 가능
* Test에서 쓸 properties 파일 설정 - `@TestPropertySource`